### PR TITLE
Unclosed files in loadf and dumpf.

### DIFF
--- a/nginx/main.py
+++ b/nginx/main.py
@@ -295,7 +295,8 @@ def load(fobj):
 	return loads(fobj.read())
 
 def loadf(path):
-	return load(open(path, 'r'))
+	with open(path, 'r') as f:
+		return load(f)
 
 def dumps(obj):
 	return ''.join(obj.as_block())
@@ -305,5 +306,6 @@ def dump(obj, fobj):
 	return fobj
 
 def dumpf(obj, path):
-	dump(obj, open(path, 'w'))
+	with open(path, 'w') as f:
+		dump(obj, f)
 	return path


### PR DESCRIPTION
Maybe you intended it like this, but normally you would want to close files after operation. The context manager do that for you. Let me know what you think.