### PR TITLE
Allow empty configs

### DIFF
--- a/nginx.py
+++ b/nginx.py
@@ -104,7 +104,8 @@ class Conf(object):
             else:
                 for y in x.as_strings:
                     ret.append(y)
-        ret[-1] = re.sub('}\n+$', '}\n', ret[-1])
+        if ret:
+            ret[-1] = re.sub('}\n+$', '}\n', ret[-1])
         return ret
 
 


### PR DESCRIPTION
Just a fix to enable saving an empty config (and calling the as_string function on empty Conf). 

In order to reproduce this bug simply do:

```
nginx.Conf().as_strings
```