### PR TITLE
WIP: Keep space chars in qotes

### DIFF
--- a/nginx.py
+++ b/nginx.py
@@ -18,6 +18,10 @@ def bump_child_depth(obj, depth):
         bump_child_depth(child, child._depth)
 
 
+def keep_special_chars(s):
+    return s.decode('string-escape').encode('string-escape').replace(r"\'", "'")
+
+
 class Conf(object):
     """
     Represents an nginx configuration.
@@ -364,8 +368,10 @@ class Key(object):
 
         :param *args: Any objects to include in this Server block.
         """
-        self.name = name
-        self.value = value
+
+        self.name = keep_special_chars(name)
+        self.value = keep_special_chars(value)
+
 
     @property
     def as_list(self):
@@ -380,6 +386,7 @@ class Key(object):
     @property
     def as_strings(self):
         """Return key as nginx config string."""
+
         if self.value == '' or self.value is None:
             return '{0};\n'.format(self.name)
         if '"' not in self.value and (';' in self.value or '#' in self.value):

--- a/nginx.py
+++ b/nginx.py
@@ -19,7 +19,12 @@ def bump_child_depth(obj, depth):
 
 
 def keep_special_chars(s):
-    return s.decode('string-escape').encode('string-escape').replace(r"\'", "'")
+    if re.search(r'\s+', s):
+        if '\'' in s and '\\' not in s:
+            return s.encode('unicode-escape')
+        elif '"' in s and '\\' not in s:
+            return s.encode('string-escape')
+    return s
 
 
 class Conf(object):
@@ -368,10 +373,8 @@ class Key(object):
 
         :param *args: Any objects to include in this Server block.
         """
-
         self.name = keep_special_chars(name)
         self.value = keep_special_chars(value)
-
 
     @property
     def as_list(self):
@@ -386,7 +389,6 @@ class Key(object):
     @property
     def as_strings(self):
         """Return key as nginx config string."""
-
         if self.value == '' or self.value is None:
             return '{0};\n'.format(self.name)
         if '"' not in self.value and (';' in self.value or '#' in self.value):

--- a/tests.py
+++ b/tests.py
@@ -122,7 +122,6 @@ server {
 }
 """
 
-
 TESTBLOCK_CASE_6 = """
 upstream test0 {
     server 1.1.1.1:8080;
@@ -157,10 +156,10 @@ server {
 
 TESTBLOCK_CASE_8 = r"""
 server {
-    double_qoted "GET /alive.html  HTTP/1.0\n\r\n\r";
-    single_quoted 'GET /alive.html  HTTP/1.0\n\r\n\r';
+    double_qoted "GET /alive.html  HTTP/1.0\r\n\r\n";
+    single_quoted 'GET /alive.html  HTTP/1.0\r\n\r\n';
     two_keys "\n \t";
-    "\nthee" "\rkeys" '\tkeys';
+    "\nthree" "\rkeys" '\tkeys';
     different_chars "\n\r\t\x01\x02\x03";
 }
 """


### PR DESCRIPTION
After issue #20 got closed I still thought there was one more "bug" than described in the issue itself. The `Key`: 
```
check_http_send "GET /alive.html  HTTP/1.0\r\n\r\n";
```
 became:
```
check_http_send "GET /alive.html  HTTP/1.0

";
```

Which seems wrong. I've now added a `keep_special_chars` to fix this small bug and added a test case for it. (Also switched places for the actual/expected values in assert functions, they were in the incorrect order before)