### PR TITLE
Enable parsing of LimitExcept

### DIFF
--- a/nginx.py
+++ b/nginx.py
@@ -436,35 +436,35 @@ def loads(data, conf=True):
             index += m.end()
             continue
 
-        m = re.compile(r'^\s*location\s*(.*?\S+)\s*{', re.S).search(data[index:])
+        m = re.compile(r'^\s*location\s*(.*?)\s*{', re.S).search(data[index:])
         if m:
             l = Location(m.group(1))
             lopen.insert(0, l)
             index += m.end()
             continue
 
-        m = re.compile(r'^\s*if\s*(.*?\S+)\s*{', re.S).search(data[index:])
+        m = re.compile(r'^\s*if\s*(.*?)\s*{', re.S).search(data[index:])
         if m:
             ifs = If(m.group(1))
             lopen.insert(0, ifs)
             index += m.end()
             continue
 
-        m = re.compile(r'^\s*upstream\s*(.*?\S+)\s*{', re.S).search(data[index:])
+        m = re.compile(r'^\s*upstream\s*(.*?)\s*{', re.S).search(data[index:])
         if m:
             u = Upstream(m.group(1))
             lopen.insert(0, u)
             index += m.end()
             continue
 
-        m = re.compile(r'^\s*geo\s*(.*?\S+)\s*{', re.S).search(data[index:])
+        m = re.compile(r'^\s*geo\s*(.*?)\s*{', re.S).search(data[index:])
         if m:
             g = Geo(m.group(1))
             lopen.insert(0, g)
             index += m.end()
             continue
 
-        m = re.compile(r'^\s*map\s*(.*?\S+)\s*{', re.S).search(data[index:])
+        m = re.compile(r'^\s*map\s*(.*?)\s*{', re.S).search(data[index:])
         if m:
             g = Map(m.group(1))
             lopen.insert(0, g)

--- a/nginx.py
+++ b/nginx.py
@@ -471,6 +471,13 @@ def loads(data, conf=True):
             index += m.end()
             continue
 
+        m = re.compile(r'^\s*limit_except\s*(.*?)\s*{', re.S).search(data[index:])
+        if m:
+            l = LimitExcept(m.group(1))
+            lopen.insert(0, l)
+            index += m.end()
+            continue
+
         m = re.compile(r'^(\s*)#\s*(.*?)\n', re.S).search(data[index:])
         if m:
             c = Comment(m.group(2), inline='\n' not in m.group(1))

--- a/tests.py
+++ b/tests.py
@@ -155,6 +155,12 @@ server {
 }
 """
 
+TESTBLOCK_CASE_8 = """
+location /M01 {
+    proxy_pass http://backend;
+    limit_except GET POST {deny all;}
+}
+"""
 
 
 class TestPythonNginx(unittest.TestCase):
@@ -240,6 +246,18 @@ class TestPythonNginx(unittest.TestCase):
         data = nginx.loads(TESTBLOCK_CASE_1)
         self.assertEqual(len(data.server.filter('Key', 'mykey')), 1)
         self.assertEqual(data.server.filter('Key', 'nothere'), [])
+
+    def test_limit_expect(self):
+        data = nginx.loads(TESTBLOCK_CASE_8)
+        self.assertEqual(len(data.filter("Location")), 1)
+        self.assertEqual(len(data.filter("Location")[0].children), 2)
+        self.assertEqual(len(data.filter("Location")[0].filter("LimitExcept")), 1)
+        limit_except = data.filter("Location")[0].filter("LimitExcept")[0]
+        self.assertEqual(limit_except.value, "GET POST")
+        self.assertEqual(len(limit_except.children), 1)
+        first_key = limit_except.filter("Key")[0]
+        self.assertEqual(first_key.name, "deny")
+        self.assertEqual(first_key.value, "all")
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
The limit_except blocks were never parsed (although there already was a class for this block).

Should solve https://github.com/peakwinter/python-nginx/issues/28

Also cleared up regex of Container code a bit removing the `\S+` after `(.*?)` which already contains all chars including non-space characters so it shouldn't change anything.