### PR TITLE
Fix bug with quoted second key value

### DIFF
--- a/nginx.py
+++ b/nginx.py
@@ -500,13 +500,14 @@ def loads(data, conf=True):
             index += m.end()
             continue
 
-        s1 = r'("[^"]+"|\'[^\']+\'|[^\s;]+)'
-        s2 = r'("[^"]*"|\'[^\']*\'|[^\s;]*)'
-        s3 = r'(\s*[^;]*?)'
-        key = r'^\s*{}\s*{}{};'.format(s1, s2, s3)
-        m = re.compile(key, re.S).search(data[index:])
+        double = r'\s*"[^"]*"'
+        single = r'\s*\'[^\']*\''
+        normal = r'\s*[^;\s]*'
+        s1 = r'{}|{}|{}'.format(double, single, normal)
+        s = r'^\s*({})\s*((?:{})+);'.format(s1, s1)
+        m = re.compile(s, re.S).search(data[index:])
         if m:
-            k = Key(m.group(1), m.group(2) + m.group(3))
+            k = Key(m.group(1), m.group(2))
             if lopen and isinstance(lopen[0], (Container, Server)):
                 lopen[0].add(k)
             else:

--- a/tests.py
+++ b/tests.py
@@ -162,6 +162,11 @@ location /M01 {
 }
 """
 
+TESTBLOCK_CASE_9 = """
+location test9 {
+    add_header X-XSS-Protection "1;mode-block";
+}
+"""
 
 class TestPythonNginx(unittest.TestCase):
     def test_basic_load(self):
@@ -258,6 +263,14 @@ class TestPythonNginx(unittest.TestCase):
         first_key = limit_except.filter("Key")[0]
         self.assertEqual(first_key.name, "deny")
         self.assertEqual(first_key.value, "all")
+
+    def test_semicolon_in_second_key_value(self):
+        inp_data = nginx.loads(TESTBLOCK_CASE_9)
+        self.assertEqual(len(inp_data.filter("Location")), 1)
+        location_children = inp_data.filter("Location")[0].children
+        self.assertEqual(len(location_children), 1)
+        self.assertEqual(location_children[0].name, "add_header")
+        self.assertEqual(location_children[0].value, 'X-XSS-Protection "1;mode-block"')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Should solve #30.

Refactors the regex for key/value nginx directives so both key and 1-X values follow the same pattern and accepts: single quoted strings, double quoted strings and not quoted strings until the `;` char is reached.