### PR TITLE
Improve if condition for required last semi colon

### DIFF
--- a/nginx.py
+++ b/nginx.py
@@ -515,7 +515,7 @@ def loads(data, conf=True):
             index += m.end()
             continue
 
-        if ";" not in data[index:] and index+1 != len(data):
+        if ";" not in data[index:] and "}" in data[index:]:
             # If there is still something to parse, expect ';' otherwise
             # the Key regexp can get stuck due to regexp catastrophic backtracking
             raise ParseError("Config syntax, missing ';' at index: {}".format(index))

--- a/tests.py
+++ b/tests.py
@@ -194,6 +194,10 @@ server{
 }
 """
 
+TESTBLOCK_CASE_12 = """
+server{
+}"""
+
 
 class TestPythonNginx(unittest.TestCase):
     def test_basic_load(self):
@@ -311,6 +315,9 @@ class TestPythonNginx(unittest.TestCase):
         with pytest.raises(nginx.ParseError) as e:
             nginx.loads(TESTBLOCK_CASE_11)
         self.assertEqual(str(e.value), "Config syntax, missing ';' at index: 189")
+
+    def test_server_without_last_linebreak(self):
+        self.assertTrue(nginx.loads(TESTBLOCK_CASE_12) is not None)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Found by @zyyoo in [issue #35 comment](https://github.com/peakwinter/python-nginx/issues/35#issuecomment-678587831) the if statement condition for last missing `;` was flaky if there was a last extra line break missing.

* Check if there are any close block chars `}` instead of comparing index with data length.
* Add new test for config with block missing last line break