### PR TITLE
feat: Add useful info when using on terminal

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,9 @@
 name: Python package
 
-on: [push]
+on:
+  push:
+  pull_request:
+    types: [opened, synchronize]
 
 jobs:
   build:

--- a/nginx.py
+++ b/nginx.py
@@ -252,6 +252,9 @@ class Comment(object):
         self.comment = comment
         self.inline = inline
 
+    def __repr__(self):
+        return "<nginx.Comment object ({0})>".format(self.comment)
+
     @property
     def as_list(self):
         """Return comment as nested list of strings."""
@@ -299,6 +302,9 @@ class Location(Container):
         super(Location, self).__init__(value, *args)
         self.name = 'location'
 
+    def __repr__(self):
+        return "<nginx.Location object ({0})>".format(self.value)
+
 
 class Events(Container):
     """Container for Event-based options."""
@@ -344,6 +350,9 @@ class Upstream(Container):
         super(Upstream, self).__init__(value, *args)
         self.name = 'upstream'
 
+    def __repr__(self):
+        return "<nginx.Upstream object ({0})>".format(self.value)
+
 
 class Geo(Container):
     """
@@ -366,6 +375,9 @@ class Map(Container):
         super(Map, self).__init__(value, *args)
         self.name = 'map'
 
+    def __repr__(self):
+        return "<nginx.Map object ({0})>".format(self.value)
+
 
 class Stream(Container):
     """Container for stream sections in the main NGINX conf file."""
@@ -387,6 +399,9 @@ class Key(object):
         """
         self.name = name
         self.value = value
+
+    def __repr__(self):
+        return "<nginx.Key object ({0})>".format(self.name)
 
     @property
     def as_list(self):

--- a/tests.py
+++ b/tests.py
@@ -39,6 +39,11 @@ upstream php
 {
     server unix:/tmp/php-fcgi.socket;
 }
+map $request_body $tmp_body
+{
+    "" "-";
+    default $request_body;
+}
 server
 {
 listen 80;  # This comment should be present;
@@ -353,6 +358,25 @@ class TestPythonNginx(unittest.TestCase):
     def test_server_without_last_linebreak(self):
         self.assertTrue(nginx.loads(TESTBLOCK_CASE_13) is not None)
         self.assertTrue(nginx.loads(TESTBLOCK_CASE_14) is not None)
+
+    def test_useful_info_on_terminal(self):
+        data = nginx.loads(TESTBLOCK_CASE_2)
+
+        upstream = data.children[0]
+        self.assertEqual(str(upstream), '<nginx.Upstream object (php)>')
+
+        key = upstream.children[0]
+        self.assertEqual(str(key), '<nginx.Key object (server)>')
+
+        nginx_map = data.children[1]
+        self.assertEqual(str(nginx_map), '<nginx.Map object ($request_body $tmp_body)>')
+
+        server = data.children[2]
+        comment = server.children[1]
+        self.assertEqual(str(comment), '<nginx.Comment object (This comment should be present;)>')
+
+        location = server.children[-1]
+        self.assertEqual(str(location), '<nginx.Location object (/)>')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Instead of getting info about memory position, now we receive info that
helps us navigate the nginx conf structure on some cases. For example:
Before: <nginx.Key object at 0x7fe420e7c2b0>
After: <nginx.Key object (log_format)>